### PR TITLE
copy dataframe as a table

### DIFF
--- a/thanosql/parse.py
+++ b/thanosql/parse.py
@@ -9,9 +9,10 @@ def convert_local_ns(query_string, local_ns) -> str:
         key: val for key, val in local_ns.items() if not isinstance(val, ModuleType)
     }
 
-    # variables need to be converted
-    # below code finds all the variables come after "=" and "FROM"
-    var_list = list(set(t[1].strip(' ') for t in re.findall(r"(=|FROM)( *?\w+)", query_string)))
+    # find variables need to be converted
+    # below codes find all the variables come after "=" and "FROM"
+    regex = '(=|FROM)( *?\w+)'
+    var_list = list(set(t[1].strip(' ') for t in re.findall(regex, query_string)))
 
     # modifying query_string
     for i in range(len(var_list)):

--- a/thanosql/parse.py
+++ b/thanosql/parse.py
@@ -10,7 +10,8 @@ def convert_local_ns(query_string, local_ns) -> str:
     }
 
     # variables need to be converted
-    var_list = list(set(map(str.strip, re.findall(r"FROM( *?\w+)", query_string))))
+    # below code finds all the variables come after "=" and "FROM"
+    var_list = list(set(t[1].strip(' ') for t in re.findall(r"(=|FROM)( *?\w+)", query_string)))
 
     # modifying query_string
     for i in range(len(var_list)):

--- a/thanosql/parse.py
+++ b/thanosql/parse.py
@@ -1,4 +1,5 @@
 import re
+import pandas as pd
 from types import ModuleType
 
 
@@ -14,7 +15,10 @@ def convert_local_ns(query_string, local_ns) -> str:
     # modifying query_string
     for i in range(len(var_list)):
         var = local_ns.get(var_list[i])
-        if var:
+        if var is not None:
+            if isinstance(var, pd.DataFrame):
+                var = var.to_json(orient="records", force_ascii=False)
+                
             query_string = query_string.replace(var_list[i], f"'{str(var)}'")
 
     return query_string

--- a/thanosql/parse.py
+++ b/thanosql/parse.py
@@ -15,15 +15,15 @@ def convert_local_ns(query_string, local_ns) -> str:
     var_list = list(set(t[1].strip(' ') for t in re.findall(regex, query_string)))
 
     # modifying query_string
-    for i in range(len(var_list)):
-        var = local_ns.get(var_list[i])
-        if var is not None:
-            if isinstance(var, pd.DataFrame):
-                var = var.to_json(orient="records", force_ascii=False)
+    for var in var_list:
+        local_var = local_ns.get(var)
+        if local_var is not None:
+            if isinstance(local_var, pd.DataFrame):
+                local_var = local_var.to_json(orient="records", force_ascii=False)
 
-            query_string = query_string.replace(var_list[i], f"'{str(var)}'")
-
-    return query_string
+            query_string = query_string.replace(var, f"'{str(local_var)}'")
+        
+        return query_string
 
 
 def is_url(s):

--- a/thanosql/parse.py
+++ b/thanosql/parse.py
@@ -10,17 +10,18 @@ def convert_local_ns(query_string, local_ns) -> str:
     }
 
     # find variables need to be converted
-    # below codes find all the variables come after "=" and "FROM"
-    regex = '(=|FROM)( *?\w+)'
-    var_list = list(set(t[1].strip(' ') for t in re.findall(regex, query_string)))
+    regex1 = '=( *?\w+)' # regex to find variables coming after "="
+    regex2 = 'FROM( *?\w+)' # regex to find variables coming after "FROM"
+    var_list = list(set(''.join(res).strip(' ') for res in re.findall(f'{regex1}|{regex2}', query_string)))
 
     # modifying query_string
     for var in var_list:
-        local_var = local_ns.get(var)
-        if local_var is not None:
+        if var in local_ns:
+            local_var = local_ns[var]
+            
             if isinstance(local_var, pd.DataFrame):
                 local_var = local_var.to_json(orient="records", force_ascii=False)
-
+            
             query_string = query_string.replace(var, f"'{str(local_var)}'")
         
         return query_string

--- a/thanosql/parse.py
+++ b/thanosql/parse.py
@@ -10,7 +10,7 @@ def convert_local_ns(query_string, local_ns) -> str:
     }
 
     # variables need to be converted
-    var_list = list(set(map(str.strip, re.findall(r"=( *?\w+)", query_string))))
+    var_list = list(set(map(str.strip, re.findall(r"FROM( *?\w+)", query_string))))
 
     # modifying query_string
     for i in range(len(var_list)):
@@ -18,7 +18,7 @@ def convert_local_ns(query_string, local_ns) -> str:
         if var is not None:
             if isinstance(var, pd.DataFrame):
                 var = var.to_json(orient="records", force_ascii=False)
-                
+
             query_string = query_string.replace(var_list[i], f"'{str(var)}'")
 
     return query_string


### PR DESCRIPTION
COPY Clause Improvement 
before : users could only create a table using a file (csv, pickle, xlsx). 
after : the implementation of code allows users to create a table using a dataframe defined in his or her workspace.
